### PR TITLE
Fix for new packageinfo format

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Libraries:
 
 * aiohttp
 * [steam](https://github.com/ValvePython/steam)
+
 Install using the commands:
 ```
 pip install aiohttp

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Libraries:
 
 * aiohttp
 * [steam](https://github.com/ValvePython/steam)
-Note: steam 1.0.0alpha required, PyPI only has 0.9.1
-Install using the following command:
+Install using the commands:
 ```
-pip install git+https://github.com/ValvePython/steam#egg=steam
+pip install aiohttp
+pip install steam
 ```
 
 ### Running

--- a/vdf.py
+++ b/vdf.py
@@ -324,7 +324,6 @@ def binary_loads_at(s, idx=0, mapper=dict, merge_duplicate_keys=True, alt_format
             except:
                 result = result.decode('utf-8', 'replace')
         return result, end + (2 if wide else 1)
-
     stack = [mapper()]
     
     CURRENT_BIN_END = BIN_END if not alt_format else BIN_END_ALT
@@ -332,7 +331,7 @@ def binary_loads_at(s, idx=0, mapper=dict, merge_duplicate_keys=True, alt_format
     while len(s) > idx:
         t = s[idx:idx+1]
         idx += 1
-
+        
         if t == CURRENT_BIN_END:
             if len(stack) > 1:
                 stack.pop()
@@ -498,16 +497,16 @@ def appinfo_loads(data):
 
 
 def packageinfo_loads(data):
-
     # These should always be present.
     version, universe = struct.unpack_from("<II",data,0)
     offset = 8
-    if version != 0x06565527 and universe != 1:
+    if version != 0x06565528 and universe != 1:
         raise ValueError("Invalid package header")
     result = {}
     # Parsing applications
     package_fields = namedtuple("Package",'checksum change_number')
     package_struct = struct.Struct("<20sI")
+    pics_struct = struct.Struct("<Q")
     while True:
         package_id = struct.unpack_from('<I',data,offset)[0]
         offset += 4
@@ -520,7 +519,7 @@ def packageinfo_loads(data):
         package = package_fields._make(package_struct.unpack_from(data,offset))
 
         offset += package_struct.size
-        
+        offset += pics_struct.size
         package, offset = binary_loads_at(data,offset)
 
         result[package_id] = package[str(package_id)]

--- a/vdf.py
+++ b/vdf.py
@@ -324,6 +324,7 @@ def binary_loads_at(s, idx=0, mapper=dict, merge_duplicate_keys=True, alt_format
             except:
                 result = result.decode('utf-8', 'replace')
         return result, end + (2 if wide else 1)
+
     stack = [mapper()]
     
     CURRENT_BIN_END = BIN_END if not alt_format else BIN_END_ALT
@@ -331,7 +332,7 @@ def binary_loads_at(s, idx=0, mapper=dict, merge_duplicate_keys=True, alt_format
     while len(s) > idx:
         t = s[idx:idx+1]
         idx += 1
-        
+
         if t == CURRENT_BIN_END:
             if len(stack) > 1:
                 stack.pop()
@@ -497,10 +498,11 @@ def appinfo_loads(data):
 
 
 def packageinfo_loads(data):
+
     # These should always be present.
     version, universe = struct.unpack_from("<II",data,0)
     offset = 8
-    if version != 0x06565528 and universe != 1:
+    if version != 0x06565527 and universe != 1:
         raise ValueError("Invalid package header")
     result = {}
     # Parsing applications
@@ -519,7 +521,9 @@ def packageinfo_loads(data):
         package = package_fields._make(package_struct.unpack_from(data,offset))
 
         offset += package_struct.size
+        
         offset += pics_struct.size
+        
         package, offset = binary_loads_at(data,offset)
 
         result[package_id] = package[str(package_id)]

--- a/vdf.py
+++ b/vdf.py
@@ -502,7 +502,7 @@ def packageinfo_loads(data):
     # These should always be present.
     version, universe = struct.unpack_from("<II",data,0)
     offset = 8
-    if version != 0x06565527 and universe != 1:
+    if version != 0x06565528 and universe != 1:
         raise ValueError("Invalid package header")
     result = {}
     # Parsing applications


### PR DESCRIPTION
As reported in #16, the downloader throws a Syntax error due to the changed Steam packageinfo format. Added a 64bit uint to the offset before sending it to binary_loads_at.

Confirmed working with this fix.

the uint64 is a picstoken, whatever that is:
https://github.com/SteamDatabase/SteamAppInfo